### PR TITLE
feat: add swagger api docs with openapi spec

### DIFF
--- a/packages/http-client/cypress/fixtures/users/get-users.json
+++ b/packages/http-client/cypress/fixtures/users/get-users.json
@@ -1,10 +1,16 @@
 [
   {
     "id": 1,
-    "name": "John doe"
+    "name": "John",
+    "email": "john@email.com",
+    "phone": "0965432123",
+    "status": "active"
   },
   {
     "id": 2,
-    "name": "Sammy doe"
+    "name": "Sammy",
+    "email": "sammy@email.com",
+    "phone": "2165432123",
+    "status": "active"
   }
 ]

--- a/packages/http-client/cypress/integration/unit-tests/users.spec.ts
+++ b/packages/http-client/cypress/integration/unit-tests/users.spec.ts
@@ -3,12 +3,12 @@ import { IUser } from '../../../src/types/users'
 
 describe('test users', () => {
   before(function () {
-    cy.fixture('users/get-users.json').as('getUsersPayload')
+    cy.fixture('users/get-users.json').as('allUsersPayload')
   })
 
-  it('get users', async function () {
-    const users: IUser[] = (await usersHttpClient.getUsers()) || []
+  it('get all users', async function () {
+    const users: IUser[] = (await usersHttpClient.getAllUsers()) || []
 
-    expect(users).to.deep.equal(this.getUsersPayload)
+    expect(users).to.deep.equal(this.allUsersPayload)
   })
 })

--- a/packages/http-client/src/services/users.ts
+++ b/packages/http-client/src/services/users.ts
@@ -2,18 +2,18 @@ import { AxiosResponse } from 'axios'
 import { axiosInstance } from '../config/axios'
 import { IUser } from '../types/users'
 
-const getUsers = async (): Promise<IUser[] | undefined> => {
+const getAllUsers = async (): Promise<IUser[] | undefined> => {
   try {
-    const response: AxiosResponse = await axiosInstance.get('/users')
+    const response: AxiosResponse = await axiosInstance.get('/api/v1/users')
 
     if (response.status === 200) {
       return response.data
     }
   } catch (e) {
-    console.log(`%chttp-client:getUsers ${e}`, 'background:red;color:#fff')
+    console.log(`%chttp-client:getAllUsers ${e}`, 'background:red;color:#fff')
   }
 }
 
 export default {
-  getUsers,
+  getAllUsers,
 }

--- a/packages/http-client/src/types/users.ts
+++ b/packages/http-client/src/types/users.ts
@@ -1,4 +1,7 @@
 export type IUser = {
   id: number
   name: string
+  email: string
+  status: string
+  phone: number
 }

--- a/packages/react-app/src/App.tsx
+++ b/packages/react-app/src/App.tsx
@@ -14,7 +14,7 @@ export default class App extends Component<Props, State> {
     this.state = { users: [] }
   }
   async componentDidMount() {
-    const users: IUser[] = (await usersHttpClient.getUsers()) || []
+    const users: IUser[] = (await usersHttpClient.getAllUsers()) || []
     this.setState({ users })
   }
 
@@ -30,7 +30,7 @@ export default class App extends Component<Props, State> {
             <h3>Users data from server</h3>
             {this.state.users.map((user: IUser, index: number) => (
               <div key={index}>
-                {user.id} - {user.name}
+                {user.id} - {user.name} - {user.email} - {user.phone}
               </div>
             ))}
           </div>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/swagger-jsdoc": "^6.0.1",
+    "@types/swagger-ui-express": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
     "@typescript-eslint/parser": "^4.27.0",
     "eslint": "^7.11.0",
@@ -38,6 +40,8 @@
   },
   "dependencies": {
     "@yarnpkg/pnpify": "^3.1.1-rc.6",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "swagger-jsdoc": "^6.1.0",
+    "swagger-ui-express": "^4.2.0"
   }
 }

--- a/packages/server/src/api-docs/open-api.json
+++ b/packages/server/src/api-docs/open-api.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "version": "1.0.0",
+    "title": "An Express Example server api - OpenAPI 3.0.2",
+    "description": "This is a sample express server on the OpenAPI 3.0 specification. The source API definition example at https://petstore3.swagger.io/api/v3/openapi.json . Validate OpenAPI 3.0 at https://petstore3.swagger.io/"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [{ "url": "http://localhost:8001/api/v1" }],
+  "tags": [
+    {
+      "name": "User",
+      "description": "Access all user endpoints",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "tags": ["User"],
+        "description": "Get all users",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/users/{name}": {
+      "get": {
+        "tags": ["User"],
+        "description": "Get a user using name. Click on try it out and input some user's name and click on execute.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name to query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "username": { "type": "string", "example": "theUser" },
+          "email": { "type": "string", "example": "john@email.com" },
+          "phone": { "type": "string", "example": "12345" },
+          "status": {
+            "type": "string",
+            "example": "active"
+          }
+        },
+        "xml": { "name": "user" }
+      }
+    },
+    "requestBodies": {
+      "UserArray": {
+        "description": "List of user object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/components/schemas/User" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/server/src/config/swagger.ts
+++ b/packages/server/src/config/swagger.ts
@@ -1,0 +1,16 @@
+import swaggerUi from 'swagger-ui-express'
+import openApiSpec from '../api-docs/open-api.json'
+
+import swaggerJsDoc, { OAS3Options } from 'swagger-jsdoc'
+
+const options: OAS3Options = {
+  apis: [],
+  swaggerDefinition: openApiSpec,
+}
+
+const specs = swaggerJsDoc(options)
+
+export default {
+  swaggerServe: swaggerUi.serve,
+  swaggerSetup: swaggerUi.setup(specs),
+}

--- a/packages/server/src/controllers/users.ts
+++ b/packages/server/src/controllers/users.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from 'express'
+
+export const getUsers = (req: Request, res: Response) => {
+  const { name } = req.params
+  res.set(200).send({
+    id: 1,
+    name: name,
+    email: name + '@email.com',
+    phone: '0965432123',
+    status: 'active',
+  })
+}
+
+export const getAllUsers = (req: Request, res: Response) => {
+  res.set(200).send([
+    {
+      id: 1,
+      name: 'John',
+      email: 'john@email.com',
+      phone: '0965432123',
+      status: 'active',
+    },
+    {
+      id: 2,
+      name: 'Sammy',
+      email: 'sammy@email.com',
+      phone: '2165432123',
+      status: 'active',
+    },
+  ])
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,13 @@
-import express, { Application, Request, Response } from 'express'
+import express, { Application } from 'express'
 import { allowCros } from './config/cors'
+import swaggerOptions from './config/swagger'
+import { userRoutes } from './routes/users'
+
+// TODO: Move to config variables or environment variables
+const port = 8001
+const API_BASE = '/api/v1'
 
 const app: Application = express()
-const port = 8001
-
 // app cors
 app.use(allowCros)
 
@@ -11,18 +15,15 @@ app.use(allowCros)
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 
-app.get('/users', async (req: Request, res: Response): Promise<Response> => {
-  return res.status(200).send([
-    {
-      id: 1,
-      name: 'John doe',
-    },
-    {
-      id: 2,
-      name: 'Sammy doe',
-    },
-  ])
-})
+// swagger docs
+app.use(
+  API_BASE + '/docs',
+  swaggerOptions.swaggerServe,
+  swaggerOptions.swaggerSetup
+)
+
+// api routes
+app.use(API_BASE + '/users', userRoutes)
 
 try {
   app.listen(port, (): void => {

--- a/packages/server/src/routes/users.ts
+++ b/packages/server/src/routes/users.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+import * as usersController from '../controllers/users'
+
+const router = Router()
+
+router.get('/', usersController.getAllUsers)
+router.get('/:name', usersController.getUsers)
+
+export const userRoutes = router

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -60,7 +60,8 @@
     // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true
   },
   "include": [
     "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,48 @@ __metadata:
   version: 5
   cacheKey: 8
 
+"@apidevtools/json-schema-ref-parser@npm:^9.0.6":
+  version: 9.0.9
+  resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
+  dependencies:
+    "@jsdevtools/ono": ^7.1.3
+    "@types/json-schema": ^7.0.6
+    call-me-maybe: ^1.0.1
+    js-yaml: ^4.1.0
+  checksum: b21f6bdd37d2942c3967ee77569bc74fadd1b922f688daf5ef85057789a2c3a7f4afc473aa2f3a93ec950dabb6ef365f8bd9cf51e4e062a1ee1e59b989f8f9b4
+  languageName: node
+  linkType: hard
+
+"@apidevtools/openapi-schemas@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "@apidevtools/openapi-schemas@npm:2.1.0"
+  checksum: 4a8f64935b9049ef21e41fa4b188f39f6bc3f5291cebd451701db1115451ccb246a739e46cc5ce9ecdec781671431db40db7851acdac84a990a45756e0f32de3
+  languageName: node
+  linkType: hard
+
+"@apidevtools/swagger-methods@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@apidevtools/swagger-methods@npm:3.0.2"
+  checksum: d06b1ac5c1956613c4c6be695612ef860cd4e962b93a509ca551735a328a856cae1e33399cac1dcbf8333ba22b231746f3586074769ef0e172cf549ec9e7eaae
+  languageName: node
+  linkType: hard
+
+"@apidevtools/swagger-parser@npm:10.0.2":
+  version: 10.0.2
+  resolution: "@apidevtools/swagger-parser@npm:10.0.2"
+  dependencies:
+    "@apidevtools/json-schema-ref-parser": ^9.0.6
+    "@apidevtools/openapi-schemas": ^2.0.4
+    "@apidevtools/swagger-methods": ^3.0.2
+    "@jsdevtools/ono": ^7.1.3
+    call-me-maybe: ^1.0.1
+    z-schema: ^4.2.3
+  peerDependencies:
+    openapi-types: ">=7"
+  checksum: fbae8e363c4944c10b9c5702a9b64d04ce2d55b5418d0ca4ef044aeaa92c7f3160ba8d3e335798f7482ab1179d947bdd7393cddf9861d76393789d7559ddf7ba
+  languageName: node
+  linkType: hard
+
 "@arcanis/slice-ansi@npm:^1.1.1":
   version: 1.1.1
   resolution: "@arcanis/slice-ansi@npm:1.1.1"
@@ -2063,6 +2105,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsdevtools/ono@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "@jsdevtools/ono@npm:7.1.3"
+  checksum: 2297fcd472ba810bffe8519d2249171132844c7174f3a16634f9260761c8c78bc0428a4190b5b6d72d45673c13918ab9844d706c3ed4ef8f62ab11a2627a08ad
+  languageName: node
+  linkType: hard
+
 "@mb/http-client@1.0.0, @mb/http-client@workspace:packages/http-client":
   version: 0.0.0-use.local
   resolution: "@mb/http-client@workspace:packages/http-client"
@@ -2107,6 +2156,8 @@ __metadata:
   resolution: "@mb/server@workspace:packages/server"
   dependencies:
     "@types/express": ^4.17.13
+    "@types/swagger-jsdoc": ^6.0.1
+    "@types/swagger-ui-express": ^4.1.3
     "@typescript-eslint/eslint-plugin": ^4.27.0
     "@typescript-eslint/parser": ^4.27.0
     "@yarnpkg/pnpify": ^3.1.1-rc.6
@@ -2115,6 +2166,8 @@ __metadata:
     express: ^4.17.1
     lint-staged: ^11.0.0
     prettier: ^2.3.1
+    swagger-jsdoc: ^6.1.0
+    swagger-ui-express: ^4.2.0
     tsc-watch: ^4.5.0
     typescript: ^4.5.2
   languageName: unknown
@@ -2603,7 +2656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:^4.17.13":
+"@types/express@npm:*, @types/express@npm:^4.17.13":
   version: 4.17.13
   resolution: "@types/express@npm:4.17.13"
   dependencies:
@@ -2693,7 +2746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
   checksum: 259d0e25f11a21ba5c708f7ea47196bd396e379fddb79c76f9f4f62c945879dc21657904914313ec2754e443c5018ea8372362f323f30e0792897fdb2098a705
@@ -2894,6 +2947,23 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/swagger-jsdoc@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@types/swagger-jsdoc@npm:6.0.1"
+  checksum: c15fcbf7415d7da6bfe908a44160a96ed9706844f74187f3424a6e65f822e08bc4f26e0fffd3bedb0f1eff60d8618952d105f31c0742df8c94e6c6b0fa9de59a
+  languageName: node
+  linkType: hard
+
+"@types/swagger-ui-express@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@types/swagger-ui-express@npm:4.1.3"
+  dependencies:
+    "@types/express": "*"
+    "@types/serve-static": "*"
+  checksum: 1c990fa8c158f699c5443245383daef2c4b47efce715c105e67f9b88447cf23663774393fdeea7d5a6e97a83d6959b09129f19c4abca64abdb7db74517162295
   languageName: node
   linkType: hard
 
@@ -3820,6 +3890,13 @@ __metadata:
   dependencies:
     sprintf-js: ~1.0.2
   checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
   languageName: node
   linkType: hard
 
@@ -4857,6 +4934,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-me-maybe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "call-me-maybe@npm:1.0.1"
+  checksum: d19e9d6ac2c6a83fb1215718b64c5e233f688ebebb603bdfe4af59cde952df1f2b648530fab555bf290ea910d69d7d9665ebc916e871e0e194f47c2e48e4886b
+  languageName: node
+  linkType: hard
+
 "caller-callsite@npm:^2.0.0":
   version: 2.0.0
   resolution: "caller-callsite@npm:2.0.0"
@@ -5362,7 +5446,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0":
+"commander@npm:6.2.0":
+  version: 6.2.0
+  resolution: "commander@npm:6.2.0"
+  checksum: 59baef90f07ba8ae941e9d41a0a15be721d69e948ff833c218d936ffbbe2141580ce1ae2b1103c41436c30eefd1eb7bc3285de8936cd283fb78409f54a93f45a
+  languageName: node
+  linkType: hard
+
+"commander@npm:^2.20.0, commander@npm:^2.7.1":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -6480,21 +6571,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"doctrine@npm:3.0.0, doctrine@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "doctrine@npm:3.0.0"
+  dependencies:
+    esutils: ^2.0.2
+  checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
 "doctrine@npm:^2.1.0":
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
   dependencies:
     esutils: ^2.0.2
   checksum: a45e277f7feaed309fe658ace1ff286c6e2002ac515af0aaf37145b8baa96e49899638c7cd47dccf84c3d32abfc113246625b3ac8f552d1046072adee13b0dc8
-  languageName: node
-  linkType: hard
-
-"doctrine@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "doctrine@npm:3.0.0"
-  dependencies:
-    esutils: ^2.0.2
-  checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
   languageName: node
   linkType: hard
 
@@ -8218,6 +8309,20 @@ __metadata:
   dependencies:
     is-glob: ^4.0.1
   checksum: f4f2bfe2425296e8a47e36864e4f42be38a996db40420fe434565e4480e3322f18eb37589617a98640c5dc8fdec1a387007ee18dbb1f3f5553409c34d17f425e
+  languageName: node
+  linkType: hard
+
+"glob@npm:7.1.6":
+  version: 7.1.6
+  resolution: "glob@npm:7.1.6"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 351d549dd90553b87c2d3f90ce11aed9e1093c74130440e7ae0592e11bbcd2ce7f0ebb8ba6bfe63aaf9b62166a7f4c80cb84490ae5d78408bb2572bf7d4ee0a6
   languageName: node
   linkType: hard
 
@@ -10250,6 +10355,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
 "jsbn@npm:~0.1.0":
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
@@ -10759,6 +10875,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
+  languageName: node
+  linkType: hard
+
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
+  languageName: node
+  linkType: hard
+
 "lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
@@ -10770,6 +10900,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.mergewith@npm:^4.6.2":
+  version: 4.6.2
+  resolution: "lodash.mergewith@npm:4.6.2"
+  checksum: a6db2a9339752411f21b956908c404ec1e088e783a65c8b29e30ae5b3b6384f82517662d6f425cc97c2070b546cc2c7daaa8d33f78db7b6e9be06cd834abdeb8
   languageName: node
   linkType: hard
 
@@ -15739,6 +15876,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swagger-jsdoc@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "swagger-jsdoc@npm:6.1.0"
+  dependencies:
+    commander: 6.2.0
+    doctrine: 3.0.0
+    glob: 7.1.6
+    lodash.mergewith: ^4.6.2
+    swagger-parser: 10.0.2
+    yaml: 2.0.0-1
+  bin:
+    swagger-jsdoc: bin/swagger-jsdoc.js
+  checksum: b0fc7e50d2c605c8b3fe2caeae4317b59bd1d0b7a18826b98c723cfd3a6bbda8b9702c90345ea58ca202b9ae94da4c28a2784015f82f0b2ff07e8109e8fe19f5
+  languageName: node
+  linkType: hard
+
+"swagger-parser@npm:10.0.2":
+  version: 10.0.2
+  resolution: "swagger-parser@npm:10.0.2"
+  dependencies:
+    "@apidevtools/swagger-parser": 10.0.2
+  checksum: 02aa7d6caa5dde20fe93f00928a7803b11099a7cffa70c1750b89add23e8dfb220ee5354d3f691dce91300f25dd155060be9a28ed7772d6aa4ff4ab3f5a36db0
+  languageName: node
+  linkType: hard
+
+"swagger-ui-dist@npm:>3.52.5":
+  version: 4.1.2
+  resolution: "swagger-ui-dist@npm:4.1.2"
+  checksum: 477dbc06606c53912a44c9982c4df847a2e4732025a397c1840933fc0c116f184860b49aa6a2b67157d3c56a924f506a020d780cac7acdb606a343e0af21bf55
+  languageName: node
+  linkType: hard
+
+"swagger-ui-express@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "swagger-ui-express@npm:4.2.0"
+  dependencies:
+    swagger-ui-dist: ">3.52.5"
+  peerDependencies:
+    express: ">=4.0.0"
+  checksum: e87255305edc2e48629d836f5839ecf31d031fffaacf029e2f34ea0823b72a5031302aae0d6a51d4eda5963ab731768028b97b990fa0f5dcceefdd9de2073aba
+  languageName: node
+  linkType: hard
+
 "symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
@@ -16638,6 +16818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"validator@npm:^13.6.0":
+  version: 13.7.0
+  resolution: "validator@npm:13.7.0"
+  checksum: 2b83283de1222ca549a7ef57f46e8d49c6669213348db78b7045bce36a3b5843ff1e9f709ebf74574e06223461ee1f264f8cc9a26a0060a79a27de079d8286ef
+  languageName: node
+  linkType: hard
+
 "vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
@@ -17328,6 +17515,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:2.0.0-1":
+  version: 2.0.0-1
+  resolution: "yaml@npm:2.0.0-1"
+  checksum: ccfbd1424dbf205a8828593faa91dfd40bd21e3fb575e257280d3526ade9508f3ea0acbe7605abc81bac6b4d6729ddb5b3de6bd818232f48480fd1eda8d7fd4c
+  languageName: node
+  linkType: hard
+
 "yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
@@ -17428,5 +17622,22 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"z-schema@npm:^4.2.3":
+  version: 4.2.4
+  resolution: "z-schema@npm:4.2.4"
+  dependencies:
+    commander: ^2.7.1
+    lodash.get: ^4.4.2
+    lodash.isequal: ^4.5.0
+    validator: ^13.6.0
+  dependenciesMeta:
+    commander:
+      optional: true
+  bin:
+    z-schema: bin/z-schema
+  checksum: 9afc0b8d4f75122fbbac8835b0398fc6ab3cfa3f68792e4e86edcd9be1e9ae9d982368a8ae25a4eeea6aad3ab35a24379b76e1525b105c23169c4f93b3185004
   languageName: node
   linkType: hard


### PR DESCRIPTION
this change adds swagger api documentation to the server package.
It uses openapi v3.0.2 spec for documenting the apis. Also small
refactors to adjust the api according to openapi spec.